### PR TITLE
Update dependencies to `op-succinct` tag `v2.0.0`

### DIFF
--- a/hierophant/Cargo.lock
+++ b/hierophant/Cargo.lock
@@ -702,6 +702,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core 0.4.5",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -764,6 +765,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1207,7 +1219,6 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bincode",
- "csv",
  "dotenv",
  "log",
  "reqwest",
@@ -1329,27 +1340,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1600,7 +1590,8 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "ecdsa"
 version = "0.16.9"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -1634,7 +1625,6 @@ dependencies = [
  "ff 0.13.1",
  "generic-array 0.14.7",
  "group 0.13.0",
- "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2158,15 +2148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,16 +2667,15 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-4.1.0#dbb97456cb6bda207eb212011ac834582263e88b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "hex",
  "once_cell",
  "sha2",
  "signature",
- "sp1-lib",
 ]
 
 [[package]]
@@ -3163,14 +3143,13 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "hex",
  "primeorder",
  "sha2",
- "sp1-lib",
 ]
 
 [[package]]
@@ -3640,8 +3619,9 @@ dependencies = [
 
 [[package]]
 name = "primeorder"
-version = "0.13.1"
-source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-4.1.0#f527279b192e0d1b293108af2faee513495411ca"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
 ]
@@ -4128,7 +4108,8 @@ dependencies = [
 [[package]]
 name = "rfc6979"
 version = "0.4.0"
-source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
@@ -4570,7 +4551,8 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4580,7 +4562,8 @@ dependencies = [
 [[package]]
 name = "sha3"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4829,18 +4812,6 @@ checksum = "b0ba97497d039db1d23db979173ae5572911773c1386487d6401f32e742db598"
 dependencies = [
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "4.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4b2747ae411bca4ba0dd4112779246b101ac7e8f70afc1a33cf8ee003980d7"
-dependencies = [
- "bincode",
- "elliptic-curve",
- "serde",
- "sp1-primitives",
 ]
 
 [[package]]
@@ -5405,9 +5376,9 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0#d2ffd330259c8f290b07d99cc1ef1f74774382c2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "cfg-if",
  "crunchy",
 ]
 
@@ -6634,8 +6605,3 @@ dependencies = [
  "sha3",
  "subtle",
 ]
-
-[[patch.unused]]
-name = "substrate-bn"
-version = "0.6.0"
-source = "git+https://github.com/sp1-patches/bn?tag=patch-0.6.0-sp1-4.0.0#1bd84110963662fae88baa5ad07c9ab92b6acdbb"

--- a/hierophant/Cargo.toml
+++ b/hierophant/Cargo.toml
@@ -1,114 +1,137 @@
 [workspace]
 members = [
-  "hierophant",
-  "contemplant",
-  # "network-lib",
+	"hierophant",
+	"contemplant",
+	# "network-lib",
 ]
 resolver = "2"
 
 [workspace.package]
 license = "AGPL-3.0-only"
-authors = [ "Tim Clancy <tim-clancy.eth>" ]
+authors = ["Joss Duff <jossduff.eth>", "Tim Clancy <tim-clancy.eth>"]
 edition = "2024"
 
+# Dependencies forked from https://github.com/succinctlabs/op-succinct tag v2.0.0
+# Uncomment dependencies as needed
 [workspace.dependencies]
 # general
 anyhow = { version = "1.0.86", default-features = false }
-thiserror = { version = "2.0.3" }
-cfg-if = "1.0.0"
-spin = { version = "0.9.8" }
-lru = "0.12.3"
-async-trait = "0.1.80"
-sha2 = "0.10.8"
+# thiserror = { version = "2.0.3" }
+# cfg-if = "1.0.0"
+# spin = { version = "0.9.8" }
+# lru = "0.12.3"
+# async-trait = "0.1.80"
+# sha2 = "0.10.8"
 tokio = { version = "1.40.0", features = ["full"] }
-clap = "4.5.9"
-cargo_metadata = "0.18.1"
+# clap = "4.5.9"
+# cargo_metadata = "0.18.1"
 dotenv = "0.15.0"
-num-format = "0.4.4"
-futures = "0.3.30"
-serde_cbor = "0.11.2"
+# num-format = "0.4.4"
+# futures = "0.3.30"
+# serde_cbor = "0.11.2"
 log = "0.4.22"
-itertools = "0.13.0"
+# itertools = "0.13.0"
 reqwest = { version = "0.12", features = ["json"] }
-csv = "1.3.0"
+# csv = "1.3.0"
 serde = { version = "1.0.198", features = ["derive"] }
 serde_json = { version = "1.0.117", default-features = false }
-rkyv = { version = "0.8", features = ["hashbrown-0_15", "std"] }
+# rkyv = { version = "0.8", features = ["hashbrown-0_15", "std"] }
 hex = "0.4.3"
 bincode = "1.3.3"
 base64 = "0.22.1"
 tower-http = { version = "0.5.2", features = ["limit"] }
-tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
-# kona
-kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9", default-features = false }
-kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9", features = [
-	"rkyv",
-	"serde",
-] }
-kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.9" }
-
-# Alloy (Network)
-alloy-network = { version = "0.11.0", default-features = false }
-alloy-signer-local = { version = "0.11.0", default-features = false }
-alloy-provider = { version = "0.11.0", default-features = false }
-alloy-transport = { version = "0.11.0", default-features = false }
-alloy-transport-http = { version = "0.11.0", default-features = false }
-alloy-contract = { version = "0.11.0", default-features = false }
-# Alloy
-alloy-rlp = { version = "0.3.10", default-features = false }
-alloy-trie = { version = "0.7.8", default-features = false }
-alloy-eips = { version = "0.11.0", default-features = false }
-alloy-serde = { version = "0.11.0", default-features = false }
-alloy-consensus = { version = "0.11.0", default-features = false }
-alloy-rpc-types = { version = "0.11.0", default-features = false }
-alloy-rpc-client = { version = "0.11.0", default-features = false }
-alloy-node-bindings = { version = "0.11.0", default-features = false }
-alloy-rpc-types-engine = { version = "0.11.0", default-features = false }
-alloy-rpc-types-beacon = { version = "0.11.0", default-features = false }
-alloy-rpc-types-eth = { version = "0.11.0", default-features = false }
+# tracing = { version = "0.1.40", default-features = false }
+# tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
+# metrics = "0.24.1"
+# metrics-exporter-prometheus = "0.16.2"
+# metrics-process = "2.4.0"
+# strum = "0.27.1"
+# strum_macros = "0.27.1"
+#
+# # kona
+# kona-mpt = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-derive = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", default-features = false }
+# kona-driver = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-preimage = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", features = [
+# 	"rkyv",
+# 	"serde",
+# ] }
+# kona-executor = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-proof = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+#
+# kona-client = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-host = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-providers-alloy = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13" }
+# kona-rpc = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", default-features = false, features = [
+# 	"serde",
+# ] }
+# kona-protocol = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", default-features = false }
+# kona-registry = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", default-features = false }
+# kona-genesis = { git = "https://github.com/op-rs/kona", tag = "kona-client/v0.1.0-beta.13", default-features = false }
+#
+# # op-succinct
+# op-succinct-prove = { path = "scripts/prove" }
+# op-succinct-client-utils = { path = "utils/client" }
+# op-succinct-host-utils = { path = "utils/host" }
+# op-succinct-build-utils = { path = "utils/build" }
+# op-succinct-validity = { path = "validity" }
+# op-succinct-fp = { path = "fault-proof" }
+#
+# # Alloy (Network)
+# alloy-signer-local = { version = "0.12.4" }
+# alloy-provider = { version = "0.12.4" }
+# alloy-transport = { version = "0.12.4" }
+# alloy-transport-http = { version = "0.12.4" }
+# alloy-contract = { version = "0.12.4" }
+# alloy-network = { version = "0.12.4" }
+#
+# # Alloy
+# alloy-rlp = { version = "0.3.10", default-features = false }
+# alloy-trie = { version = "0.7.9", default-features = false }
+# alloy-eips = { version = "0.12.4", default-features = false }
+# alloy-serde = { version = "0.12.4", default-features = false }
+# alloy-consensus = { version = "0.12.4", default-features = false }
+# alloy-rpc-types = { version = "0.12.4", default-features = false }
+# alloy-rpc-client = { version = "0.12.4", default-features = false }
+# alloy-node-bindings = { version = "0.12.4", default-features = false }
+# alloy-rpc-types-engine = { version = "0.12.4", default-features = false }
+# alloy-rpc-types-beacon = { version = "0.12.4", default-features = false }
+# alloy-rpc-types-eth = { version = "0.12.4", default-features = false }
+# alloy-signer = { version = "0.12.4", default-features = false }
+#
 # Keccak with the SHA3 patch is more efficient than the default Keccak.
-alloy-primitives = { version = "0.8.19", default-features = false, features = [
+alloy-primitives = { version = "0.8.21", default-features = false, features = [
 	"sha3-keccak",
 ] }
-alloy-sol-types = { version = "0.8.19", default-features = false }
-alloy-sol-macro = { version = "0.8.19", default-features = false }
-# OP Alloy
-op-alloy-consensus = { version = "=0.10.3", default-features = false }
-op-alloy-rpc-types = { version = "=0.10.3", default-features = false }
-op-alloy-rpc-types-engine = { version = "=0.10.3", default-features = false }
-op-alloy-network = { version = "=0.10.3", default-features = false }
-# Maili
-maili-consensus = { version = "0.2.6", default-features = false }
-maili-rpc = { version = "0.2.6", default-features = false, features = [
-	"serde",
-] }
-maili-protocol = { version = "0.2.6", default-features = false }
-maili-registry = { version = "0.2.6", default-features = false }
-maili-genesis = { version = "0.2.6", default-features = false }
-# Revm
-revm = { version = "19.5.0", default-features = false, features = ["kzg-rs"] }
-# SP1
-sp1-lib = { version = "4.1.0", features = ["verify"] }
-sp1-sdk = { version = "4.1.0" }
-sp1-zkvm = { version = "4.1.0", features = ["verify", "embedded"] }
-sp1-build = { version = "4.1.0" }
-kzg-rs = { version = "0.2.5" }
-[profile.release-client-lto]
-inherits = "release"
-panic = "abort"
-codegen-units = 1
-lto = "fat"
-[patch.crates-io]
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
-sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
-substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-4.0.0" }
-sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
-p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
-k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
+# alloy-sol-types = { version = "0.8.21", default-features = false }
+# alloy-sol-macro = { version = "0.8.21", default-features = false }
+#
+# # OP Alloy
+# op-alloy-consensus = { version = "0.11.0", default-features = false }
+# op-alloy-rpc-types = { version = "0.11.0", default-features = false }
+# op-alloy-rpc-types-engine = { version = "0.11.0", default-features = false }
+# op-alloy-network = { version = "0.11.0", default-features = false }
+#
+# # Revm
+# revm = { version = "19.5.0", default-features = false, features = ["kzg-rs"] }
+#
+# # SP1
+sp1-sdk = { version = "4.1.3" }
+# sp1-lib = { version = "4.1.3", features = ["verify"] }
+# sp1-zkvm = { version = "4.1.3", features = ["verify"] }
+# sp1-build = { version = "4.1.3" }
+# kzg-rs = { version = "0.2.5" }
+#
+# [profile.release-client-lto]
+# inherits = "release"
+# panic = "abort"
+# codegen-units = 1
+# lto = "fat"
+#
+# [patch.crates-io]
+# tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
+# sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
+# substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-4.0.0" }
+# sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
+# p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
+# k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }

--- a/hierophant/contemplant/Cargo.toml
+++ b/hierophant/contemplant/Cargo.toml
@@ -26,9 +26,8 @@ anyhow.workspace = true
 dotenv.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-csv.workspace = true
 # server
-axum = "0.7.4"
+axum = { version = "0.7.4", features = ["macros"] }
 bincode.workspace = true
 log.workspace = true
 base64.workspace = true

--- a/hierophant/hierophant/Cargo.toml
+++ b/hierophant/hierophant/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1.0"
 [build-dependencies]
 tonic-build = "0.10.0"
 
-# TODO: Joss coordinator dependencies
 # [dependencies]
 # # workspace
 # tokio.workspace = true


### PR DESCRIPTION
Use latest dependencies, referencing `op-succinct` tag `v2.0.0` deps 
[https://github.com/succinctlabs/op-succinct/releases/tag/v2.0.0](https://github.com/succinctlabs/op-succinct/releases/tag/v2.0.0)

Also it now compiles