### PR TITLE
feat: allow passing of moongate url in contemplant config

### DIFF
--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -6,6 +6,13 @@ pub struct Config {
     pub contemplant_name: String,
     #[serde(default = "default_port")]
     pub port: usize,
+    // If None, then the contemplant spins up a cuda prover docker container
+    #[serde(default = "default_moongate_endpoint")]
+    pub moongate_endpoint: Option<String>,
+}
+
+fn default_moongate_endpoint() -> Option<String> {
+    None
 }
 
 fn default_port() -> usize {

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -45,7 +45,17 @@ async fn main() -> Result<()> {
     // Set up the SP1 SDK logger.
     utils::setup_logger();
 
-    let cuda_prover = Arc::new(ProverClient::builder().cuda().build());
+    let cuda_prover = match &config.moongate_endpoint {
+        // build with undockerized moongate server
+        Some(moongate_endpoint) => Arc::new(
+            ProverClient::builder()
+                .cuda()
+                .with_moongate_endpoint(moongate_endpoint)
+                .build(),
+        ),
+        // spin up cuda prover docker container
+        None => Arc::new(ProverClient::builder().cuda().build()),
+    };
     let mock_prover = Arc::new(ProverClient::builder().mock().build());
     info!("Prover built");
 


### PR DESCRIPTION
New contemplant config value `moongate_url`.  Defaults to `None`, but if one is provided, then builds the CudaProver with that url.

closes #15 