### PR TITLE
feat: signal to proposer to re-try failed requests

### DIFF
--- a/hierophant/hierophant/src/hierophant_state.rs
+++ b/hierophant/hierophant/src/hierophant_state.rs
@@ -105,10 +105,20 @@ pub struct ProofStatus {
 }
 
 impl ProofStatus {
+    /*
+    If the fulfillment_status is Unfulfillable && ExecutionStatus is NOT Unexecutable then the proposer will re-try the same span proof request.
+    We set the fulfillment_status to Unfulfillable because we want the proposer to re-try this request but we set execution status to Unspecified because
+    we DON'T want the proposer to split it into 2 requests
+
+    [from op-succinct/validity/src/proof_requester ln 303]:
+    If the request is a range proof and the number of failed requests is greater than 2 or the execution status is unexecutable, the request is split into two new requests.
+    Otherwise, add_new_ranges will insert the new request. This ensures better failure-resilience. If the request to add two range requests fails, add_new_ranges will handle it gracefully by submitting
+    the same range.
+    */
     pub fn lost() -> Self {
         Self {
             fulfillment_status: FulfillmentStatus::Unfulfillable.into(),
-            execution_status: ExecutionStatus::Unexecutable.into(),
+            execution_status: ExecutionStatus::UnspecifiedExecutionStatus.into(),
             proof: vec![],
         }
     }


### PR DESCRIPTION
closes #14 

 If the fulfillment_status is Unfulfillable && ExecutionStatus is NOT Unexecutable then the proposer will re-try the same span proof request.
We set the fulfillment_status to Unfulfillable because we want the proposer to re-try this request but we set execution status to Unspecified because we DON'T want the proposer to split it into 2 requests


From [https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proof_requester.rs#L296](https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proof_requester.rs#L296):
```
    /// If the request is a range proof and the number of failed requests is greater than 2 or the
    /// execution status is unexecutable, the request is split into two new requests. Otherwise,
    /// add_new_ranges will insert the new request. This ensures better failure-resilience. If the
    /// request to add two range requests fails, add_new_ranges will handle it gracefully by
    /// submitting the same range.
```
(A failed request is one whos `FulfillmentStatus` is `Unfulfillable` see [https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L347](https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L347))

You might notice that this only specifies retrying span proof requests.  Failed agg proofs stay failed, but then are re-requested on the next iteration of the main execution loop when the proposer checks to see if it should create a agg proof:

From [https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L361](https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L361):
```rust
/// Create aggregation proofs based on the completed range proofs. The range proofs must be
/// contiguous and have the same range vkey commitment. Assumes that the range proof retry
/// logic guarantees that there is not two potential contiguous chains of range proofs.
///
/// Only creates an Aggregation proof if there's not an Aggregation proof in progress with the
/// same start block.
#[tracing::instrument(name = "proposer.create_aggregation_proofs", skip(self))]
pub async fn create_aggregation_proofs(&self) -> Result<()> {...}
```

`create_aggregation_proofs` is called in the main execution loop [https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L1142](https://github.com/succinctlabs/op-succinct/blob/57c3febb196215291ea25bdad2559eda91f88077/validity/src/proposer.rs#L1142)