### PR TITLE
feat: different ports for contemplant server

### DIFF
--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -10,8 +10,10 @@ pub struct Config {
     #[serde(default = "default_contemplant_name")]
     pub contemplant_name: String,
     #[serde(default = "default_port")]
-    pub port: usize,
-    // If None, then the contemplant spins up a cuda prover docker container
+    pub internal_port: usize,
+    #[serde(default = "default_port")]
+    pub external_port: usize,
+    // If None, then the contemplant spins up a CUDA prover Docker container.
     #[serde(default = "default_moongate_endpoint")]
     pub moongate_endpoint: Option<String>,
 }

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -7,21 +7,21 @@ use types::ProofFromNetwork;
 
 use crate::config::Config;
 use crate::types::{AppError, ProofStore};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use axum::{
-    Json, Router,
     extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     routing::{get, post},
+    Json, Router,
 };
 use log::{error, info};
 use network_lib::{
-    CONTEMPLANT_VERSION, ContemplantProofRequest, ContemplantProofStatus,
-    REGISTER_CONTEMPLANT_ENDPOINT, WorkerRegisterInfo,
+    ContemplantProofRequest, ContemplantProofStatus, WorkerRegisterInfo, CONTEMPLANT_VERSION,
+    REGISTER_CONTEMPLANT_ENDPOINT,
 };
 use reqwest::Client;
 use sp1_sdk::{
-    CpuProver, CudaProver, Prover, ProverClient, network::proto::network::ProofMode, utils,
+    network::proto::network::ProofMode, utils, CpuProver, CudaProver, Prover, ProverClient,
 };
 use std::str::FromStr;
 use std::{collections::HashMap, sync::Arc};
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
         .layer(DefaultBodyLimit::disable())
         .with_state(worker_state);
 
-    let port = config.port.to_string();
+    let port = config.internal_port.to_string();
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
         .await
         .unwrap();
@@ -99,7 +99,7 @@ fn register_worker(config: Config) {
     let worker_register_info = WorkerRegisterInfo {
         contemplant_version: CONTEMPLANT_VERSION.into(),
         name: config.contemplant_name.clone(),
-        port: config.port,
+        port: config.external_port,
     };
     info!(
         "Sending hierophant at {} worker_register_info {:?}",


### PR DESCRIPTION
Some environments that `contemplant` might run in will force remapping of the internal port to an external port that needs to be defined separately. This should go away when we resolve #27.