### PR TITLE
Native gnark

### DIFF
--- a/hierophant/Cargo.toml
+++ b/hierophant/Cargo.toml
@@ -122,7 +122,6 @@ alloy-primitives = { version = "1.0.0", default-features = false, features = [
 # revm = { version = "19.5.0", default-features = false, features = ["kzg-rs"] }
 #
 # # SP1
-sp1-sdk = { version = "4.2.0" }
 # sp1-lib = { version = "4.1.3", features = ["verify"] }
 # sp1-zkvm = { version = "4.1.3", features = ["verify"] }
 # sp1-build = { version = "4.1.3" }
@@ -141,3 +140,9 @@ sp1-sdk = { version = "4.2.0" }
 # sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 # p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
 # k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
+# By default uses sp1-sdk that assumes docker.  `RUSTFLAGS="--cfg enable_native_gnark" cargo build` when running undockerized moongate
+sp1-sdk = { version = "4.2.0" }
+
+# use `cargo build --features enable-native-gnark` when building a binary that uses undockerized cudaProver
+[features]
+enable-native-gnark = ["sp1-sdk/native-gnark"]

--- a/hierophant/Cargo.toml
+++ b/hierophant/Cargo.toml
@@ -140,5 +140,4 @@ alloy-primitives = { version = "1.0.0", default-features = false, features = [
 # sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
 # p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
 # k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
-# By default uses sp1-sdk that assumes docker.  `RUSTFLAGS="--cfg enable_native_gnark" cargo build` when running undockerized moongate
 sp1-sdk = { version = "4.2.0" }

--- a/hierophant/Cargo.toml
+++ b/hierophant/Cargo.toml
@@ -142,7 +142,3 @@ alloy-primitives = { version = "1.0.0", default-features = false, features = [
 # k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
 # By default uses sp1-sdk that assumes docker.  `RUSTFLAGS="--cfg enable_native_gnark" cargo build` when running undockerized moongate
 sp1-sdk = { version = "4.2.0" }
-
-# use `cargo build --features enable-native-gnark` when building a binary that uses undockerized cudaProver
-[features]
-enable-native-gnark = ["sp1-sdk/native-gnark"]

--- a/hierophant/README.md
+++ b/hierophant/README.md
@@ -23,6 +23,12 @@ Install `protoc`: [https://protobuf.dev/installation/](https://protobuf.dev/inst
 
 `cargo build`
 
+If you're building a contemplant that uses an undockerized CudaProver (setting a moongate_endpoint in contemplant.toml), build with the feature `enable-native-gnark`:
+
+```
+cargo build --release --bin contemplant --features enable-native-gnark
+```
+
 ## `old_testament.txt`
 
 List of biblical names to randomly draw from if a contemplant is started without a name.

--- a/hierophant/contemplant/Cargo.toml
+++ b/hierophant/contemplant/Cargo.toml
@@ -37,3 +37,7 @@ log.workspace = true
 base64.workspace = true
 tower-http.workspace = true
 serde_repr = "0.1.19"
+
+# use `cargo build --features enable-native-gnark` when building a binary that uses undockerized cudaProver
+[features]
+enable-native-gnark = ["sp1-sdk/native-gnark"]

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -47,6 +47,18 @@ async fn main() -> Result<()> {
     let cuda_prover = match &config.moongate_endpoint {
         // build with undockerized moongate server
         Some(moongate_endpoint) => {
+            // make sure the `native-gnark` feature is enabled.  Otherwise the contemplant will
+            // error when it tries to finish a GROTH16 proof
+            #[cfg(not(feature = "enable-native-gnark"))]
+            {
+                eprintln!(
+                    "Error: Using an undockerized moongate CUDA prover requires the enable-native-gnark feature."
+                );
+                eprintln!("Please rebuild with: cargo build --features enable-native-gnark");
+                panic!(
+                    "Build with feature `enable-native-gnark` or use dockerized moongate CUDA prover"
+                );
+            }
             info!("Building CudaProver with moongate endpoint {moongate_endpoint}...");
             Arc::new(
                 ProverClient::builder()

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -51,13 +51,9 @@ async fn main() -> Result<()> {
             // error when it tries to finish a GROTH16 proof
             #[cfg(not(feature = "enable-native-gnark"))]
             {
-                eprintln!(
-                    "Error: Using an undockerized moongate CUDA prover requires the enable-native-gnark feature."
-                );
-                eprintln!("Please rebuild with: cargo build --features enable-native-gnark");
-                panic!(
-                    "Build with feature `enable-native-gnark` or use dockerized moongate CUDA prover"
-                );
+                let error_msg = "Please rebuild with: `--features enable-native-gnark` or remove moongate_endpoint in cargo.toml to use the dockerized CUDA prover";
+                error!("{error_msg}");
+                panic!("{error_msg}");
             }
             info!("Building CudaProver with moongate endpoint {moongate_endpoint}...");
             Arc::new(
@@ -69,6 +65,13 @@ async fn main() -> Result<()> {
         }
         // spin up cuda prover docker container
         None => {
+            // build using dockerized CUDA prover
+            #[cfg(feature = "enable-native-gnark")]
+            {
+                let error_msg = "Please rebuild without `--features enable-native-gnark` to use the dockerized CUDA prover or supply a moongate_endpoint to contemplant.toml";
+                error!("{error_msg}");
+                panic!("{error_msg}");
+            }
             info!("Starting CudaProver docker container...");
             Arc::new(ProverClient::builder().cuda().build())
         }

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -44,6 +44,8 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
 
+    // compiler will always complain about one of these branches being unreachable, depending on if
+    // you compiled with `features enable-native-gnark` or not
     let cuda_prover = match &config.moongate_endpoint {
         // build with undockerized moongate server
         Some(moongate_endpoint) => {


### PR DESCRIPTION
When running an undockerized moongate prover, the `native-gnark` flag also has to be supplied to `sp1-sdk` or else the contemplant will error when it's finishing a GROTH16 proof.  Added a feature flag `enable-native-gnark` to compile with for contemplant binaries that will be using undockerized moongate provers.

Also made the output of http request `/contemplants` a bit prettier because we're going to be using lots of contemplants soon.