### PR TITLE
feat(hierophant): Keep last n proofs

### DIFF
--- a/hierophant/contemplant/src/types.rs
+++ b/hierophant/contemplant/src/types.rs
@@ -95,7 +95,7 @@ impl ProofStore {
     }
 
     // yes I know, this is O(n) when it could be O(1) with a hash map BUT in practice
-    // it is much faster because self.proofs.length is single didgets, and we don't
+    // it is much faster because self.proofs.length is <10 and we don't
     // have to hash anything
     pub fn get(&self, request_id: &B256) -> Option<&ContemplantProofStatus> {
         match self

--- a/hierophant/hierophant/src/config.rs
+++ b/hierophant/hierophant/src/config.rs
@@ -38,12 +38,13 @@ pub struct Config {
     // Keeps most recently completed proofs.
     #[serde(default = "default_proof_cache_size")]
     pub proof_cache_size: usize,
-    // Where to store cached proofs on-disk
-    #[serde(default = "default_proof_cache_directory")]
-    pub proof_cache_directory: String,
     // Where artifacts are stored on-disk
     #[serde(default = "default_artifact_store_directory")]
     pub artifact_store_directory: String,
+    // Proofs can be quite large so we need to limit how many we store on-disk inside the
+    // artifact_store_directory
+    #[serde(default = "default_max_proofs_stored")]
+    pub max_proofs_stored: usize,
 }
 
 fn default_worker_response_timeout_secs() -> Duration {
@@ -56,12 +57,12 @@ fn default_max_worker_heartbeat_interval_secs() -> Duration {
     Duration::from_secs(3 * 60)
 }
 
-fn default_proof_cache_directory() -> String {
-    "proofs".into()
-}
-
 fn default_artifact_store_directory() -> String {
     "artifacts".into()
+}
+
+fn default_max_proofs_stored() -> usize {
+    10
 }
 
 fn default_proof_cache_size() -> usize {

--- a/hierophant/hierophant/src/hierophant_state.rs
+++ b/hierophant/hierophant/src/hierophant_state.rs
@@ -28,7 +28,8 @@ pub struct HierophantState {
 impl HierophantState {
     pub fn new(config: Config) -> Self {
         let proof_router = ProofRouter::new(&config);
-        let artifact_store_client = ArtifactStoreClient::new(&config.artifact_store_directory);
+        let artifact_store_client =
+            ArtifactStoreClient::new(&config.artifact_store_directory, config.max_proofs_stored);
         Self {
             config,
             proof_requests: Arc::new(Mutex::new(HashMap::new())),

--- a/hierophant/hierophant/src/http_handler.rs
+++ b/hierophant/hierophant/src/http_handler.rs
@@ -118,13 +118,6 @@ async fn handle_artifact_download(
                 display_artifact_hex(&bytes)
             );
 
-            // TODO: maybe we should periodically trim artifacts instead of deleting after download
-            // also delete the artifact after it's been downloaded by the client for storage saving
-            let _ = state
-                .artifact_store_client
-                .delete_artifact(uri.clone())
-                .await;
-
             bytes
         }
         Ok(None) => {

--- a/hierophant/hierophant/src/proof_router/worker_registry.rs
+++ b/hierophant/hierophant/src/proof_router/worker_registry.rs
@@ -7,7 +7,6 @@ use network_lib::{
     WorkerRegisterInfo,
 };
 use serde::{Serialize, Serializer};
-use serde_json::Number;
 use sp1_sdk::network::proto::network::ProofMode;
 use std::ops::ControlFlow;
 use std::{


### PR DESCRIPTION
closes #13 

New hierophant config variable `max_proofs_stored: usize` enforces that the last <max_proofs_stored> proofs completed are kept on disk.  Proofs can get quite large so this is a storage optimization.  `max_proofs_stored` defaults to 10: the last 10 proofs completed are kept on disk for hierophant, anything older is deleted.  Previously we deleted a proof after it was downloaded by a client (op-succinct), but we shouldn't keep the assumption that each proof is only downloaded once.

Also delete the `artifact` directory on startup.  We don't have any caching so new hierophant instances never need this directory.