### PR TITLE
return an assigned proof status when we cant reach worker

### DIFF
--- a/hierophant/hierophant/src/hierophant_state.rs
+++ b/hierophant/hierophant/src/hierophant_state.rs
@@ -188,6 +188,14 @@ impl ProofStatus {
             proof: vec![],
         }
     }
+
+    pub fn assigned() -> Self {
+        Self {
+            fulfillment_status: FulfillmentStatus::Assigned.into(),
+            execution_status: ExecutionStatus::Unexecuted.into(),
+            proof: vec![],
+        }
+    }
 }
 
 impl Display for ProofStatus {


### PR DESCRIPTION
closes #45 

This is small, but it solves a major issue: when a contemplant doesn't respond to a `proof_status` request before the timeout, add a strike to that contemplant and return a `ProofStatus::assigned()` to the client instead of a `ProofStatus::lost()`.  Often, a contemplant not responding to a request is a transient, 1-off issue, and the contemplant is otherwise fine.

`ProofStatus::assigned()` prompts the client to keep waiting on the proof and re-requesting the `proof_status` request.  After a few timeouts on a `proof_status` request, the contemplant is removed for good.

`ProofStatus::lost()` prompts the client to forget about the `request_id` of the proof it was looking for, and request a new proof.  In this situation, this leads to the contemplant never being removed from hierophant (client never requests the old `request_id` again, and the contemplant keeps sending heartbeat checks, so no reason to cut) and infinitely marked as `busy`.