### PR TITLE
feat: add upper bound for how many artifacts can be stored

### DIFF
--- a/hierophant/hierophant/src/config.rs
+++ b/hierophant/hierophant/src/config.rs
@@ -41,10 +41,10 @@ pub struct Config {
     // Where artifacts are stored on-disk
     #[serde(default = "default_artifact_store_directory")]
     pub artifact_store_directory: String,
-    // Proofs can be quite large so we need to limit how many we store on-disk inside the
+    // Artifacts can be quite large so we need to limit how many we store on-disk inside the
     // artifact_store_directory
-    #[serde(default = "default_max_proofs_stored")]
-    pub max_proofs_stored: usize,
+    #[serde(default = "default_max_artifacts_stored")]
+    pub max_artifacts_stored: usize,
 }
 
 fn default_worker_response_timeout_secs() -> Duration {
@@ -60,8 +60,10 @@ fn default_artifact_store_directory() -> String {
     "artifacts".into()
 }
 
-fn default_max_proofs_stored() -> usize {
-    10
+// We need to give a default to have SOME upper limit to how big the `artifact_store_directory`
+// can grow
+fn default_max_artifacts_stored() -> usize {
+    50
 }
 
 fn proof_timeout_mins() -> u64 {

--- a/hierophant/hierophant/src/hierophant_state.rs
+++ b/hierophant/hierophant/src/hierophant_state.rs
@@ -32,8 +32,10 @@ pub struct HierophantState {
 impl HierophantState {
     pub fn new(config: Config) -> Self {
         let proof_router = ProofRouter::new(&config);
-        let artifact_store_client =
-            ArtifactStoreClient::new(&config.artifact_store_directory, config.max_proofs_stored);
+        let artifact_store_client = ArtifactStoreClient::new(
+            &config.artifact_store_directory,
+            config.max_artifacts_stored,
+        );
         let cpu_prover = Arc::new(CpuProver::new());
         Self {
             config,


### PR DESCRIPTION
Borrowed logic enforcing a max number of proofs stored and changed it to having a max number of any artifact.  In the future these might need to be separate concerns tbh.  Was needed for now so artifacts/ directory doesn't grow unbounded.

closes #49 