### PR TITLE
WIP: add manager field of contemplant

### DIFF
--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -19,6 +19,13 @@ pub struct Config {
     // max number of finished proofs stored in memory
     #[serde(default = "default_max_proofs_stored")]
     pub max_proofs_stored: usize,
+    // address of the Magister managing this contemplant, if any
+    #[serde(default = "default_manager")]
+    pub manager: Option<String>,
+}
+
+fn default_manager() -> Option<String> {
+    None
 }
 
 // realistically we shouldn't need more than 1, but some edge cases require us to store more

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -43,6 +43,9 @@ async fn main() -> Result<()> {
     // Set up the SP1 SDK logger.
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
+    if let Some(magister_addr) = &config.manager {
+        info!("Contemplant is being managed by the magister at {magister_addr}");
+    }
 
     // compiler will always complain about one of these branches being unreachable, depending on if
     // you compiled with `features enable-native-gnark` or not
@@ -116,6 +119,7 @@ async fn main() -> Result<()> {
     let worker_register_info = WorkerRegisterInfo {
         contemplant_version: CONTEMPLANT_VERSION.into(),
         name: config.contemplant_name.clone(),
+        manager: config.manager,
     };
 
     info!(

--- a/hierophant/network-lib/src/lib.rs
+++ b/hierophant/network-lib/src/lib.rs
@@ -11,12 +11,14 @@ pub const REGISTER_CONTEMPLANT_ENDPOINT: &str = "register_contemplant";
 // Increment this whenever there is a breaking change in the contemplant
 // This is to ensure the contemplant is on the same version as the Hierophant it's
 // connecting to
-pub const CONTEMPLANT_VERSION: &str = "2.0.0";
+pub const CONTEMPLANT_VERSION: &str = "3.0.0";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WorkerRegisterInfo {
     pub name: String,
     pub contemplant_version: String,
+    // Address of the magister managing this contemplant, if any
+    pub manager: Option<String>,
 }
 
 impl Display for WorkerRegisterInfo {


### PR DESCRIPTION
Adds a new optional field to contemplants, `manager`, which is address of a Magister instance.  When a contemplant connection to a hierophant, it notes the managing Magister, if any.  When the Hierophant decides to kill a contemplant, it notifies the managing Magister of it's decision so the Magister can de-allocate that vast.ai instance.