### PR TITLE
feat: Magister

### DIFF
--- a/hierophant/Cargo.lock
+++ b/hierophant/Cargo.lock
@@ -760,7 +760,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "sp1-cuda",
  "sp1-sdk",
  "tempfile",
  "tokio",

--- a/hierophant/Cargo.toml
+++ b/hierophant/Cargo.toml
@@ -141,4 +141,3 @@ alloy-primitives = { version = "1.0.0", default-features = false, features = [
 # p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-4.1.0" }
 # k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
 sp1-sdk = { version = "5.0.0" }
-sp1-cuda = { version = "5.0.0" }

--- a/hierophant/contemplant/Cargo.toml
+++ b/hierophant/contemplant/Cargo.toml
@@ -26,7 +26,7 @@ tokio-tungstenite.workspace = true
 
 # sp1
 sp1-sdk.workspace = true
-sp1-cuda.workspace = true
+
 network-lib = { path = "../network-lib" }
 
 toml.workspace = true

--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -22,15 +22,13 @@ pub struct Config {
     pub max_proofs_stored: usize,
     #[serde(default = "default_assessor_config")]
     pub assessor: AssessorConfig,
-    // http endpoint of this contemplant's managing magister. When this contemplant
-    // is dropped, this endpoint is used to notify the magister to deallocate
-    // resources.
-    // (Magister http address, the contemplant's instance_id assigned in magister)
-    #[serde(default = "default_magister")]
-    pub magister: Option<MagisterInfo>,
+    // endpoint to hit to drop this contemplant from it's Magister.
+    // Only Some if this contemplant has a Magister
+    #[serde(default = "default_magister_drop_endpoint")]
+    pub magister_drop_endpoint: Option<String>,
 }
 
-fn default_magister() -> Option<MagisterInfo> {
+fn default_magister() -> Option<String> {
     None
 }
 

--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -1,3 +1,4 @@
+use network_lib::MagisterInfo;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -24,11 +25,12 @@ pub struct Config {
     // http endpoint of this contemplant's managing magister. When this contemplant
     // is dropped, this endpoint is used to notify the magister to deallocate
     // resources.
+    // (Magister http address, the contemplant's instance_id assigned in magister)
     #[serde(default = "default_magister")]
-    pub magister: Option<String>,
+    pub magister: Option<MagisterInfo>,
 }
 
-fn default_magister() -> Option<String> {
+fn default_magister() -> Option<MagisterInfo> {
     None
 }
 

--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -21,6 +21,15 @@ pub struct Config {
     pub max_proofs_stored: usize,
     #[serde(default = "default_assessor_config")]
     pub assessor: AssessorConfig,
+    // http endpoint of this contemplant's managing magister. When this contemplant
+    // is dropped, this endpoint is used to notify the magister to deallocate
+    // resources.
+    #[serde(default = "default_magister")]
+    pub magister: Option<String>,
+}
+
+fn default_magister() -> Option<String> {
+    None
 }
 
 // realistically we shouldn't need more than 1, but some edge cases require us to store more

--- a/hierophant/contemplant/src/config.rs
+++ b/hierophant/contemplant/src/config.rs
@@ -1,4 +1,3 @@
-use network_lib::MagisterInfo;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -28,7 +27,7 @@ pub struct Config {
     pub magister_drop_endpoint: Option<String>,
 }
 
-fn default_magister() -> Option<String> {
+fn default_magister_drop_endpoint() -> Option<String> {
     None
 }
 

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -54,8 +54,6 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
 
-    if let Some(endpoint) = &config.magister_drop_endpoint {}
-
     // compiler will always complain about one of these branches being unreachable, depending on if
     // you compiled with `features enable-native-gnark` or not
     let cuda_prover = match &config.moongate_endpoint {
@@ -242,7 +240,7 @@ async fn main() -> Result<()> {
             "Contemplant is being managed by the Magister with drop endpoint {}.",
             drop_endpoint
         );
-        verify_with_magister(drop_endpoint.clone()).await?
+        verify_with_magister(drop_endpoint.clone()).await?;
     }
 
     //wait for either task to finish and kill the other task

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -54,6 +54,10 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
 
+    if let Some(magister_addr) = &config.magister {
+        info!("Contemplant is being managed by the Magister at {magister_addr}");
+    }
+
     // compiler will always complain about one of these branches being unreachable, depending on if
     // you compiled with `features enable-native-gnark` or not
     let cuda_prover = match &config.moongate_endpoint {
@@ -126,6 +130,7 @@ async fn main() -> Result<()> {
     let worker_register_info = WorkerRegisterInfo {
         contemplant_version: CONTEMPLANT_VERSION.into(),
         name: config.contemplant_name.clone(),
+        magister: config.magister,
     };
 
     info!(

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -24,9 +24,8 @@ use anyhow::{Context, Result, anyhow};
 use log::{error, info, trace, warn};
 use network_lib::{
     CONTEMPLANT_VERSION, ContemplantProofRequest, ContemplantProofStatus, FromContemplantMessage,
-    FromHierophantMessage, MagisterInfo, WorkerRegisterInfo,
+    FromHierophantMessage, WorkerRegisterInfo,
 };
-use sp1_cuda::{MoongateServer, SP1CudaProver};
 use sp1_sdk::{
     CpuProver, CudaProver, Prover, ProverClient,
     network::proto::network::{ExecutionStatus, ProofMode},

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -24,7 +24,7 @@ use anyhow::{Context, Result, anyhow};
 use log::{error, info, trace, warn};
 use network_lib::{
     CONTEMPLANT_VERSION, ContemplantProofRequest, ContemplantProofStatus, FromContemplantMessage,
-    FromHierophantMessage, WorkerRegisterInfo,
+    FromHierophantMessage, MagisterInfo, WorkerRegisterInfo,
 };
 use sp1_cuda::{MoongateServer, SP1CudaProver};
 use sp1_sdk::{
@@ -55,8 +55,11 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
 
-    if let Some(magister_addr) = &config.magister {
-        info!("Contemplant is being managed by the Magister at {magister_addr}");
+    if let Some(info) = &config.magister {
+        info!(
+            "Contemplant is being managed by the Magister at {}.  This contemplant is known to the Magister as instance {}",
+            info.magister_addr, info.instance_id
+        );
     }
 
     // compiler will always complain about one of these branches being unreachable, depending on if

--- a/hierophant/contemplant/src/main.rs
+++ b/hierophant/contemplant/src/main.rs
@@ -54,10 +54,10 @@ async fn main() -> Result<()> {
     utils::setup_logger();
     info!("Starting contemplant {}", config.contemplant_name);
 
-    if let Some(info) = &config.magister {
+    if let Some(endpoint) = &config.magister_drop_endpoint {
         info!(
-            "Contemplant is being managed by the Magister at {}.  This contemplant is known to the Magister as instance {}",
-            info.magister_addr, info.instance_id
+            "Contemplant is being managed by the Magister with drop endpoint {}.",
+            endpoint
         );
     }
 
@@ -133,7 +133,7 @@ async fn main() -> Result<()> {
     let worker_register_info = WorkerRegisterInfo {
         contemplant_version: CONTEMPLANT_VERSION.into(),
         name: config.contemplant_name.clone(),
-        magister: config.magister,
+        magister_drop_endpoint: config.magister_drop_endpoint,
     };
 
     info!(

--- a/hierophant/hierophant/src/artifact_store.rs
+++ b/hierophant/hierophant/src/artifact_store.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, anyhow};
 use axum::body::Bytes;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use serde::{
     Deserialize, Deserializer,
     de::{self, Visitor},
@@ -257,7 +257,7 @@ impl ArtifactStore {
             _ => (),
         };
 
-        info!(
+        debug!(
             "Writing artifact {} to disk.  Num bytes: {}",
             artifact_uri,
             bytes.len()

--- a/hierophant/hierophant/src/http_handler.rs
+++ b/hierophant/hierophant/src/http_handler.rs
@@ -124,8 +124,6 @@ async fn handle_artifact_download(
     State(state): State<Arc<HierophantState>>,
     Path(uri): Path<ArtifactUri>,
 ) -> Result<Vec<u8>, StatusCode> {
-    info!("\n=== Received Download Request ===");
-
     let bytes = match state
         .artifact_store_client
         .get_artifact_bytes(uri.clone())
@@ -160,9 +158,7 @@ async fn handle_artifact_upload(
     Path(uri): Path<ArtifactUri>,
     body: Bytes,
 ) -> Result<impl IntoResponse, StatusCode> {
-    info!("\n=== Received Upload Request ===");
-
-    info!("Received {} bytes of artifact {uri}", body.len());
+    info!("Received {} bytes of artifact {uri} for upload", body.len());
 
     match state
         .artifact_store_client

--- a/hierophant/hierophant/src/proof_router/worker_registry.rs
+++ b/hierophant/hierophant/src/proof_router/worker_registry.rs
@@ -506,7 +506,7 @@ impl WorkerRegistry {
                 }
             }
 
-            info!(
+            debug!(
                 "Attemping to assign proof request {request_id} to worker {} at {worker_addr}",
                 worker_state.name
             );

--- a/hierophant/hierophant/src/prover_network_service.rs
+++ b/hierophant/hierophant/src/prover_network_service.rs
@@ -95,8 +95,6 @@ impl ProverNetwork for ProverNetworkService {
         &self,
         request: Request<CreateProgramRequest>,
     ) -> Result<Response<CreateProgramResponse>, Status> {
-        info!("\n=== create_program called ===");
-
         let req = request.into_inner();
 
         let body = match req.body {

--- a/hierophant/hierophant/src/ws_handler.rs
+++ b/hierophant/hierophant/src/ws_handler.rs
@@ -85,7 +85,7 @@ pub async fn handle_socket(
     tokio::select! {
         result = (&mut send_task) => {
             match result {
-                Ok(_) => info!("Send task completed normally"),
+                Ok(_) => debug!("Send task completed normally"),
                 Err(e) => error!("Send task failed with error: {e}"),
             }
             debug!("Send task exited, aborting recv task");
@@ -93,7 +93,7 @@ pub async fn handle_socket(
         },
         result = (&mut recv_task) => {
             match result {
-                Ok(_) => info!("Recv task completed normally"),
+                Ok(_) => debug!("Recv task completed normally"),
                 Err(e) => error!("Recv task failed with error: {e}"),
             }
             debug!("Recv task exited, aborting send task");

--- a/hierophant/network-lib/src/lib.rs
+++ b/hierophant/network-lib/src/lib.rs
@@ -17,48 +17,22 @@ pub const CONTEMPLANT_VERSION: &str = "6.0.0";
 pub struct WorkerRegisterInfo {
     pub name: String,
     pub contemplant_version: String,
-    // Optional field of the Magister that manages this contemplant.  The Magister
-    // will be notified when this contemplant is cut, allowing it to deallocate
-    // the contemplant's machine and create a new one
-    // (Magister http address, the contemplant's instance_id assigned in magister)
-    pub magister: Option<MagisterInfo>,
+    // endpoint to hit to drop this contemplant from it's Magister.
+    // Only Some if this contemplant has a Magister
+    pub magister_drop_endpoint: Option<String>,
 }
 
 impl Display for WorkerRegisterInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let magister_info = if let Some(magister_info) = &self.magister {
-            format!(
-                "Magister {}, instance {}",
-                magister_info.magister_addr, magister_info.instance_id
-            )
-        } else {
-            format!("")
+        let magister_info = match self.magister_drop_endpoint.clone() {
+            Some(x) => format!(" with Magister drop endpoint {x}"),
+            None => format!(""),
         };
-
         write!(
             f,
-            "{} CONTEMPLANT_VERSION {} {}",
+            "{} CONTEMPLANT_VERSION {}{}",
             self.name, self.contemplant_version, magister_info
         )
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MagisterInfo {
-    pub magister_addr: String,
-    pub instance_id: u64,
-}
-
-impl MagisterInfo {
-    pub fn new(magister_addr: String, instance_id: u64) -> Self {
-        Self {
-            magister_addr,
-            instance_id,
-        }
-    }
-
-    pub fn to_drop_url(&self) -> String {
-        format!("{}/drop/{}", self.magister_addr, self.instance_id)
     }
 }
 

--- a/hierophant/network-lib/src/lib.rs
+++ b/hierophant/network-lib/src/lib.rs
@@ -20,16 +20,45 @@ pub struct WorkerRegisterInfo {
     // Optional field of the Magister that manages this contemplant.  The Magister
     // will be notified when this contemplant is cut, allowing it to deallocate
     // the contemplant's machine and create a new one
-    pub magister: Option<String>,
+    // (Magister http address, the contemplant's instance_id assigned in magister)
+    pub magister: Option<MagisterInfo>,
 }
 
 impl Display for WorkerRegisterInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let magister_info = if let Some(magister_info) = &self.magister {
+            format!(
+                "Magister {}, instance {}",
+                magister_info.magister_addr, magister_info.instance_id
+            )
+        } else {
+            format!("")
+        };
+
         write!(
             f,
-            "{} CONTEMPLANT_VERSION {}",
-            self.name, self.contemplant_version
+            "{} CONTEMPLANT_VERSION {} {}",
+            self.name, self.contemplant_version, magister_info
         )
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MagisterInfo {
+    pub magister_addr: String,
+    pub instance_id: u64,
+}
+
+impl MagisterInfo {
+    pub fn new(magister_addr: String, instance_id: u64) -> Self {
+        Self {
+            magister_addr,
+            instance_id,
+        }
+    }
+
+    pub fn to_drop_url(&self) -> String {
+        format!("{}/drop/{}", self.magister_addr, self.instance_id)
     }
 }
 

--- a/hierophant/network-lib/src/lib.rs
+++ b/hierophant/network-lib/src/lib.rs
@@ -11,12 +11,16 @@ pub const REGISTER_CONTEMPLANT_ENDPOINT: &str = "register_contemplant";
 // Increment this whenever there is a breaking change in the contemplant
 // This is to ensure the contemplant is on the same version as the Hierophant it's
 // connecting to
-pub const CONTEMPLANT_VERSION: &str = "5.0.0";
+pub const CONTEMPLANT_VERSION: &str = "6.0.0";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WorkerRegisterInfo {
     pub name: String,
     pub contemplant_version: String,
+    // Optional field of the Magister that manages this contemplant.  The Magister
+    // will be notified when this contemplant is cut, allowing it to deallocate
+    // the contemplant's machine and create a new one
+    pub magister: Option<String>,
 }
 
 impl Display for WorkerRegisterInfo {


### PR DESCRIPTION
When Hierophant decides to kill a contemplant it also notifies the contemplant's managing [Magister](https://github.com/unattended-backpack/magister) if they have one.  The Magister will de-allocate the vast instance of that contemplant and create a new instance to replace the old one.