### PR TITLE
clean: make contemplant, hierophant, and readme update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,36 @@
 # Simple Makefile for Hierophant
-.PHONY: hierophant hierophant-d stop logs restart check-env
+.PHONY: hierophant contemplant 
 
 check-env:
 	@test -f .env || (echo "Error: .env file not found!" && exit 1)
 
 # Start in foreground
-hierophant: check-env
+prover-network: check-env
 	docker compose -f docker-compose.yml up
 
 # Start in background
-hierophant-d: check-env
+prover-network-d: check-env
 	docker compose -f docker-compose.yml up -d
 
 # Stop 
-stop:
+stop-prover-network:
 	docker compose -f docker-compose.yml down
 
 # View  logs
-logs:
+logs-prover-network:
 	docker compose -f docker-compose.yml logs -f
 
 # Restart hierophant
-restart:
+restart-prover-network:
 	docker compose -f docker-compose.yml restart
+
+# Run just the hierophant
+hierophant:
+	@test -f hierophant.toml || (echo "Error: hierophant.toml not found" && exit 1)
+	RUST_LOG=info RUST_BACKTRACE=1 cargo run --release --bin hierophant
+
+# Run just the contemplant
+contemplant:
+	@test -f contemplant.toml || (echo "Error: contemplant.toml not found" && exit 1)
+	RUST_LOG=info RUST_BACKTRACE=1 cargo run --release --bin contemplant
+

--- a/hierophant.example.toml
+++ b/hierophant.example.toml
@@ -1,6 +1,6 @@
 # REQUIRED
 
-# publicly reachable address of this Hierophant for artifact uploads
+# publicly reachable address of this Hierophant for artifact uploads by the program requesting proofs
 this_hierophant_ip = ""
 
 # OPTIONAL


### PR DESCRIPTION
`make hierophant` and `make contemplant` for local running

`make prover-network` for hierophant + magister local proof network

Also updated README to reflect these changes