### PR TITLE
feat: Contemplants default to CUDA support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,15 @@ jobs:
       id: build-native
       env:
         CARGO_HOME: ${{ github.workspace }}/.cargo
+
+        # Released contemplant binary must link risc0-zkvm/cuda; without it,
+        # operators with `backend = "cuda"` on a risc0 [[provers]] entry hit
+        # a config-load panic ("RISC Zero CUDA backend requires building the
+        # contemplant with --features enable-risc0-cuda"). The Dockerfile's
+        # CI path is BUILD_TYPE=prebuilt (skips cargo, just copies out/), so
+        # the feature set has to be baked in here at native-build time.
+        # native-gnark stays on for SP1's in-process Groth16 path.
+        CONTEMPLANT_FEATURES: enable-native-gnark,enable-risc0-cuda
       run: |
         echo "Building binaries using Makefile..."
 

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ IMAGE_TAG ?= latest
 ACT_PULL ?= true
 
 # BACKEND picks which proving backend the test targets exercise at runtime.
-#   cpu  (default); SP1 uses CpuProver; RISC Zero uses LocalProver.
+#   cpu           ; SP1 uses CpuProver; RISC Zero uses LocalProver.
 #   cuda          ; SP1 talks to an in-container moongate-server on :3000
 #                    (entrypoint auto-starts it via tmux); RISC Zero uses
 #                    in-process CUDA. Both require the container to be
 #                    launched with GPU access, which the test compose files
 #                    request via deploy.resources.reservations.devices.
-BACKEND ?= cpu
+BACKEND ?= gpu
 
 # CONTEMPLANT_FEATURES is derived from BACKEND by default so a CPU build
 # doesn't pay the (expensive, nvcc-version-sensitive) cost of compiling


### PR DESCRIPTION
## Description
We are enabling CUDA support by default such that the images which come out the other side of our CI pipeline will be more widely-deployable.